### PR TITLE
Missing parsers and xml file from pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include kinpy/mjcf_parser/schema.xml

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 __version__ = '0.0.4'
 
@@ -11,7 +11,7 @@ setup(
     license='MIT',
     keywords='robot kinematics',
     url='http://github.com/neka-nat/kinpy',
-    packages=['kinpy'],
+    packages=find_packages(), #['kinpy'],
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     install_requires=['numpy', 'scipy', 'absl-py', 'pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     keywords='robot kinematics',
     url='http://github.com/neka-nat/kinpy',
     packages=find_packages(), #['kinpy'],
+    include_package_data = True,
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     install_requires=['numpy', 'scipy', 'absl-py', 'pyyaml',


### PR DESCRIPTION
Hi, 
I tried installing kinpy from pip on OSX, and the urdf_parser and mjcf_parser submodules are not copied in the installation.
I'm definitely not an expert in python packaging, but the commits here seem to fix the issue. 

