### PR TITLE
Fix typo in chain.py: framd -> frame

### DIFF
--- a/kinpy/chain.py
+++ b/kinpy/chain.py
@@ -13,7 +13,7 @@ class Chain(object):
 
     @staticmethod
     def _find_frame_recursive(name, frame):
-        for child in framd.children:
+        for child in frame.children:
             if child.name == name:
                 return child
             ret = Chain._find_frame_recursive(name, child)


### PR DESCRIPTION
Just found a typo while playing around.

The second diff "No newline at end of file" is automatically created by github.