### PR TITLE
added possibility to generate jacobian for specific link

### DIFF
--- a/kinpy/chain.py
+++ b/kinpy/chain.py
@@ -1,3 +1,4 @@
+from os import link
 from typing import Dict, List, Optional, Union
 import numpy as np
 from . import frame, ik, jacobian, transform
@@ -134,8 +135,15 @@ class SerialChain(Chain):
                 cnt += 1
         return link_transforms[self._serial_frames[-1].link.name] if end_only else link_transforms
 
-    def jacobian(self, th: List[float]) -> np.ndarray:
-        return jacobian.calc_jacobian(self, th)
+    def jacobian(self, th: List[float], end_only: bool = True) -> np.ndarray:
+        if end_only:
+            return jacobian.calc_jacobian(self, th)
+        else:
+            jacobians = {}
+            for serial_frame in self._serial_frames:
+                jac = jacobian.calc_jacobian_frames(self, th, link_name=serial_frame.link.name)
+                jacobians[serial_frame.link.name] = jac
+            return jacobians
 
     def inverse_kinematics(self, pose: transform.Transform, initial_state: Optional[np.ndarray] = None) -> np.ndarray:
         return ik.inverse_kinematics(self, pose, initial_state)

--- a/kinpy/chain.py
+++ b/kinpy/chain.py
@@ -1,4 +1,3 @@
-from os import link
 from typing import Dict, List, Optional, Union
 import numpy as np
 from . import frame, ik, jacobian, transform

--- a/kinpy/jacobian.py
+++ b/kinpy/jacobian.py
@@ -1,4 +1,3 @@
-from os import link
 from typing import Any, List
 import numpy as np
 

--- a/kinpy/jacobian.py
+++ b/kinpy/jacobian.py
@@ -1,3 +1,4 @@
+from os import link
 from typing import Any, List
 import numpy as np
 
@@ -28,4 +29,44 @@ def calc_jacobian(serial_chain: Any, th: List[float], tool: transform.Transform 
     j_tr[:3, :3] = rotation
     j_tr[3:, 3:] = rotation
     j_w = np.dot(j_tr, j_fl)
+    return j_w
+
+def calc_jacobian_frames(serial_chain: Any, th: List[float], link_name: str, tool: transform.Transform = transform.Transform()) -> np.ndarray:
+    ndof = len(th)
+    j_fl = np.zeros((6, ndof))
+    cur_transform = tool.matrix()
+
+    # select first num_th movable joints
+    serial_frames = []
+    num_movable_joints = 0
+    for serial_frame in serial_chain._serial_frames:
+        serial_frames.append(serial_frame)
+        if serial_frame.joint.joint_type != "fixed":
+            num_movable_joints += 1
+
+        if serial_frame.link.name == link_name:
+            break # found first n joints
+        
+    cnt = len(th) - num_movable_joints # only first num_th joints
+    for f in reversed(serial_frames):
+        if f.joint.joint_type == "revolute":
+            cnt += 1
+            delta = np.dot(f.joint.axis, cur_transform[:3, :3])
+            d = np.dot(np.cross(f.joint.axis, cur_transform[:3, 3]), cur_transform[:3, :3])
+            j_fl[:, -cnt] = np.hstack((d, delta))
+        elif f.joint.joint_type == "prismatic":
+            cnt += 1
+            j_fl[:3, -cnt] = np.dot(f.joint.axis, cur_transform[:3, :3])
+        cur_frame_transform = f.get_transform(th[-cnt]).matrix()
+        cur_transform = np.dot(cur_frame_transform, cur_transform)
+
+    poses = serial_chain.forward_kinematics(th, end_only=False)
+    pose = poses[link_name].matrix()
+
+    rotation = pose[:3, :3]
+    j_tr = np.zeros((6, 6))
+    j_tr[:3, :3] = rotation
+    j_tr[3:, 3:] = rotation
+    j_w = np.dot(j_tr, j_fl)
+
     return j_w


### PR DESCRIPTION
Kinpy currently only supports to compute the jacobian for the whole kinematics chain.
This pull request adds a new parameter `end_only` to the `jacobian` method in the class `SerialChain`,
that allows to generate the jacobian for all links.
The interface is inspired from the `forward` and therefore returns a dictionary with the jacobians for all links.